### PR TITLE
[issue1]終了

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -28,9 +28,25 @@ class AssignsController < ApplicationController
 
   def assign_destroy(assign, assigned_user)
     if assigned_user == assign.team.owner
-      I18n.t('views.messages.cannot_delete_the_leader')
+    I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
+    elsif current_user.id != assigned_user.id
+      if current_user.id == assign.team.owner.id
+        assign.destroy
+        set_next_team(assign, assigned_user)
+        I18n.t('views.messages.delete_member')
+      else
+        I18n.t('views.messages.cannot_delete_another_member')
+      end
+    elsif current_user.id != assign.team.owner.id
+      if current_user.id == assigned_user.id
+        assign.destroy
+        set_next_team(assign, assigned_user)
+        I18n.t('views.messages.delete_member')
+      else
+        I18n.t('views.messages.only_leader_can_delete_a_member')
+      end
     elsif assign.destroy
       set_next_team(assign, assigned_user)
       I18n.t('views.messages.delete_member')

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,11 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    unless @team.owner == current_user
+     redirect_to team_path, notice:'あかんyo'
+    end
+  end
 
   def create
     @team = Team.new(team_params)
@@ -30,6 +34,9 @@ class TeamsController < ApplicationController
   end
 
   def update
+    unless @team.owner == current_user
+     redirect_to team_path, notice:'あかんyo'
+    end
     if @team.update(team_params)
       redirect_to @team, notice: I18n.t('views.messages.update_team')
     else

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,7 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' if current_user.id == @team.owner.id %>
           </div>
 
           <div class="col-md-8">


### PR DESCRIPTION
そのTeamに所属しているUserの削除（離脱）が、どのUserでもできる
TeamのeditをTeamのリーダー（オーナー）以外でも自由にできる
という仕様になっているが、これを、

Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
TeamのeditはTeamのリーダー（オーナー）のみができるようにすること
という仕様に変更すること